### PR TITLE
Wait for networking to start

### DIFF
--- a/templates/matchbox.service.j2
+++ b/templates/matchbox.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=matchbox boot service
 Documentation=https://github.com/coreos/matchbox
+Requires=network-online.target
+After=network-online.target
 
 [Service]
 User={{ matchbox_config_user }}


### PR DESCRIPTION
Wait for networking to start before starting matchbox service
Changes ref: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/